### PR TITLE
Vista para listar pacientes

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -2,38 +2,13 @@
   text-align: center;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-float infinite 3s ease-in-out;
-  }
-}
-
 .App-header {
-  min-height: 100vh;
+  // (Height of the viewport - height of the navbar)
+  // TODO: update this after include the footer
+  min-height: calc(100vh - 50px);
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   font-size: calc(10px + 2vmin);
 }
 
-.App-link {
-  color: rgb(112, 76, 182);
-}
-
-@keyframes App-logo-float {
-  0% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(10px);
-  }
-  100% {
-    transform: translateY(0px);
-  }
-}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,11 @@ import './App.scss';
 import { Routing } from './constant/Routing';
 import CreatePatient from './features/create-patient/create-patient';
 import SelectTreatments from './features/select-treatments/select-treatments';
+<<<<<<< HEAD
 import { Counter } from './features/counter/Counter';
 import Navbar from './features/navbar/navbar';
+=======
+>>>>>>> wip
 
 function App() {
   return (
@@ -18,7 +21,10 @@ function App() {
           <Route path={Routing.SELECCIONAR_PACIENTE} element={<Form/>} />
           <Route path={Routing.CREATE_PATIENT} element={<CreatePatient/>} />
           <Route path={Routing.SELECT_TREATMENTS} element={<SelectTreatments/>} />
+<<<<<<< HEAD
           <Route path={Routing.COUNTER} element={<Counter name="Pirotto"/>} />
+=======
+>>>>>>> wip
         </Routes>
       </header>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,8 @@ import './App.scss';
 import { Routing } from './constant/Routing';
 import CreatePatient from './features/create-patient/create-patient';
 import SelectTreatments from './features/select-treatments/select-treatments';
-<<<<<<< HEAD
 import { Counter } from './features/counter/Counter';
 import Navbar from './features/navbar/navbar';
-=======
->>>>>>> wip
 
 function App() {
   return (
@@ -21,10 +18,7 @@ function App() {
           <Route path={Routing.SELECCIONAR_PACIENTE} element={<Form/>} />
           <Route path={Routing.CREATE_PATIENT} element={<CreatePatient/>} />
           <Route path={Routing.SELECT_TREATMENTS} element={<SelectTreatments/>} />
-<<<<<<< HEAD
           <Route path={Routing.COUNTER} element={<Counter name="Pirotto"/>} />
-=======
->>>>>>> wip
         </Routes>
       </header>
     </div>

--- a/src/app/types/global.d.ts
+++ b/src/app/types/global.d.ts
@@ -4,3 +4,10 @@ declare interface TreatmentJSON {
   quantity: number
 }
 
+declare interface PatientInfo {
+  document_number: number,
+  first_name: string,
+  last_name: string,
+  sex: string
+}
+

--- a/src/assets/stylesheets/colors.scss
+++ b/src/assets/stylesheets/colors.scss
@@ -6,6 +6,7 @@
 */
 
 $grey-background: #f7f9fc;
+<<<<<<< HEAD
 $disabled-button-grey: #c3c5c9;
 
 // BRAND COLORS
@@ -33,3 +34,7 @@ $warning-dark: #B76206;
 $danger-light: #FF7961;
 $danger: #FF3B2D;
 $danger-dark: #B71626;
+=======
+$red-error: #e2244d;
+$red-delete-button: #bb260c;
+>>>>>>> wip

--- a/src/assets/stylesheets/colors.scss
+++ b/src/assets/stylesheets/colors.scss
@@ -7,10 +7,17 @@
 
 $grey-background: #f7f9fc;
 <<<<<<< HEAD
+<<<<<<< HEAD
 $disabled-button-grey: #c3c5c9;
 
 // BRAND COLORS
 $brand-background: #D5E9FD;
+=======
+
+$disabled-button-grey: #c3c5c9;
+
+// BRAND COLORS
+>>>>>>> Colores, boton para eliminar tratamiento y siguiente
 $brand-light: #81B3F5;
 $brand: #306fe0;
 $brand-dark: #183FA1;
@@ -34,7 +41,10 @@ $warning-dark: #B76206;
 $danger-light: #FF7961;
 $danger: #FF3B2D;
 $danger-dark: #B71626;
+<<<<<<< HEAD
 =======
 $red-error: #e2244d;
 $red-delete-button: #bb260c;
 >>>>>>> wip
+=======
+>>>>>>> Colores, boton para eliminar tratamiento y siguiente

--- a/src/assets/stylesheets/colors.scss
+++ b/src/assets/stylesheets/colors.scss
@@ -8,16 +8,27 @@
 $grey-background: #f7f9fc;
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+
+$extra-dark-grey: #4d4c4c;
+$dark-grey: #696969;
+$silver-grey: #A9A9A9;
+>>>>>>> Vista para listar pacientes
 $disabled-button-grey: #c3c5c9;
 
 // BRAND COLORS
 $brand-background: #D5E9FD;
+<<<<<<< HEAD
 =======
 
 $disabled-button-grey: #c3c5c9;
 
 // BRAND COLORS
 >>>>>>> Colores, boton para eliminar tratamiento y siguiente
+=======
+$brand-extra-light: #ACD1FB;
+>>>>>>> Vista para listar pacientes
 $brand-light: #81B3F5;
 $brand: #306fe0;
 $brand-dark: #183FA1;
@@ -42,9 +53,16 @@ $danger-light: #FF7961;
 $danger: #FF3B2D;
 $danger-dark: #B71626;
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 $red-error: #e2244d;
 $red-delete-button: #bb260c;
 >>>>>>> wip
 =======
 >>>>>>> Colores, boton para eliminar tratamiento y siguiente
+=======
+
+// SEX COLORS
+$male: #127A1E;
+$female: #921407;
+>>>>>>> Vista para listar pacientes

--- a/src/assets/stylesheets/variables.scss
+++ b/src/assets/stylesheets/variables.scss
@@ -6,7 +6,10 @@
 // Fonts
 $primary-font-family: 'MarkPro', Roboto;
 $primary-font: $primary-font-family, Arial, sans-serif;
-$form-title-size: 40px;
+$font-size-title: 40px;
+$font-size-subtitle: 24px;
+$font-size-body: 16px;
+$font-size-secondary-text: 14px;
 
 // Margins & paddings
 $padding-button: 10px;

--- a/src/constant/Routing.tsx
+++ b/src/constant/Routing.tsx
@@ -2,5 +2,8 @@ export const Routing = {
     SELECCIONAR_PACIENTE: '/seleccionar_paciente',
     CREATE_PATIENT: '/create-patient',
     SELECT_TREATMENTS: '/select-treatments',
+<<<<<<< HEAD
     COUNTER: '/counter',
+=======
+>>>>>>> wip
 }

--- a/src/constant/Routing.tsx
+++ b/src/constant/Routing.tsx
@@ -4,6 +4,10 @@ export const Routing = {
     SELECT_TREATMENTS: '/select-treatments',
 <<<<<<< HEAD
     COUNTER: '/counter',
+<<<<<<< HEAD
 =======
 >>>>>>> wip
+=======
+    LIST_PATIENTS: '/list-patients'
+>>>>>>> Vista para listar pacientes
 }

--- a/src/features/call-to-action/call-to-action.module.scss
+++ b/src/features/call-to-action/call-to-action.module.scss
@@ -1,0 +1,5 @@
+@import '../../assets/stylesheets/generic-styles.scss';
+
+.CallToAction {
+  font-size: $font-size-subtitle !important;
+}

--- a/src/features/call-to-action/call-to-action.tsx
+++ b/src/features/call-to-action/call-to-action.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Link, Typography } from '@material-ui/core';
+import styles from './call-to-action.module.scss';
+import LinkIcon from '@mui/icons-material/Link';
+
+interface CalltoActionProps {
+  text: string,
+  url: string,
+  urlText: string
+}
+
+const CallToAction = (props: CalltoActionProps) => {
+  return (
+    <Typography className={styles.CallToAction}>
+      {props.text}<Link href={props.url}>{props.urlText} <LinkIcon/></Link>
+    </Typography>
+  );
+}
+
+export default CallToAction;

--- a/src/features/navbar/navbar.module.scss
+++ b/src/features/navbar/navbar.module.scss
@@ -1,5 +1,9 @@
 @import '../../assets/stylesheets/generic-styles.scss';
 
+.NavBarContainer{
+  height: 50px;
+}
+
 .MedicalIcon {
   margin: 10px;
 }

--- a/src/features/navbar/navbar.tsx
+++ b/src/features/navbar/navbar.tsx
@@ -10,7 +10,7 @@ const Navbar = () => {
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
-        <Toolbar variant="dense">
+        <Toolbar className= {styles.NavBarContainer} variant="dense">
           <MedicalServicesIcon className= {styles.MedicalIcon}/>
           <Typography variant="h6" color="inherit" component="div">
             FINGLIX

--- a/src/features/patients-list/patients-list.module.scss
+++ b/src/features/patients-list/patients-list.module.scss
@@ -1,0 +1,26 @@
+@import '../../assets/stylesheets/generic-styles.scss';
+
+.TableContainer {
+  margin: 20px;
+  width: 90% !important;
+}
+
+.TableHeader {
+  background-color: $brand-extra-light;
+  .TableTitle {
+    th {
+      color: $extra-dark-grey;
+      font-weight: bold;
+      text-transform: capitalize;
+      font-size: $font-size-subtitle;
+    }
+  }
+}
+
+.FemaleIcon {
+  color: $female;
+}
+
+.MaleIcon {
+  color: $male;
+}

--- a/src/features/patients-list/patients-list.tsx
+++ b/src/features/patients-list/patients-list.tsx
@@ -1,0 +1,95 @@
+import React, {Fragment, useState, useEffect} from 'react';
+import styles from './patients-list.module.scss';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+import API from '../../networking/api-service';
+import { API_ROUTES } from '../../networking/api-routes';
+import FemaleIcon from '@mui/icons-material/Female';
+import MaleIcon from '@mui/icons-material/Male';
+import TableFooter from '@mui/material/TableFooter';
+import TablePagination from '@mui/material/TablePagination';
+
+const PatientsList = () => {
+  const [data, setData] = useState<PatientInfo[]>(
+    []
+  )
+  const [page, setPage] = useState(0);
+  const [countPatient, setCountPatients] = useState(0);
+
+  // We have to add 1 to the page due to materialUI table page 
+  // beginning in 0 and there is not way to change it
+  useEffect(() => {
+    API.get(API_ROUTES.LIST_PATIENTS+`?page=${page+1}`)
+    .then(res => {
+      setData(res.data.results);
+      setCountPatients(res.data.count);
+    })
+  }, [page]);
+
+  const handleChangePage = (event: any, newPage: number) => {
+    setPage(newPage);
+  };
+
+  return (
+    <Fragment>
+      <TableContainer className={styles.TableContainer}component={Paper}>
+        <Table sx={{ minWidth: 650 }} aria-label="simple table">
+          <TableHead className= {styles.TableHeader}>
+            <TableRow className= {styles.TableTitle}>
+              <TableCell align="center"> Documento </TableCell>
+              <TableCell align="center">Nombre</TableCell>
+              <TableCell align="center">Apellido</TableCell>
+              <TableCell align="center">Sexo</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.map((row) => 
+              <TableRow
+                key={row.document_number}
+                sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+              >
+                <TableCell align="center">{row.document_number}</TableCell>
+                <TableCell align="center">{row.first_name}</TableCell>
+                <TableCell align="center">{row.last_name}</TableCell>
+                {(row.sex === 'F') ? <TableCell align="center"><FemaleIcon className= {styles.FemaleIcon}/></TableCell> : <TableCell align="center"><MaleIcon className= {styles.MaleIcon}/></TableCell> } 
+              </TableRow>
+            )}
+          </TableBody>
+          <TableFooter>
+            <TableRow>
+              <TablePagination
+                count={countPatient}
+                rowsPerPage={10}
+                page={page}
+                onPageChange={handleChangePage}
+                rowsPerPageOptions={[10]}
+                labelRowsPerPage={<span>Rows:</span>}
+                labelDisplayedRows={({ page }) => {
+                  return `Página: ${page}`;
+                }}
+                backIconButtonProps={{
+                  color: "primary"
+                }}
+                nextIconButtonProps={{ color: "primary" }}
+                SelectProps={{
+                  inputProps: {
+                    "aria-label": "page number"
+                  }
+                }}
+                showFirstButton={false}
+                showLastButton={false}
+              />
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </TableContainer>
+    </Fragment>
+  );
+}
+ 
+export default PatientsList;

--- a/src/features/patients-page/patients-page.module.scss
+++ b/src/features/patients-page/patients-page.module.scss
@@ -1,0 +1,6 @@
+@import '../../assets/stylesheets/generic-styles.scss';
+
+.PageTitle {
+  padding: 10px;
+  font-size: $font-size-title !important;
+}

--- a/src/features/patients-page/patients-page.tsx
+++ b/src/features/patients-page/patients-page.tsx
@@ -1,0 +1,17 @@
+import React, {Fragment, useState, useEffect} from 'react';
+import styles from './patients-page.module.scss';
+import { Typography } from '@material-ui/core';
+import CallToAction from '../call-to-action/call-to-action';
+import PatientsList from '../patients-list/patients-list';
+
+const PatientsPage = () => {
+  return (
+      <Fragment>
+        <Typography className={styles.PageTitle}> Lista de Pacientes </Typography>
+        <PatientsList/>
+        <CallToAction text='En caso de querer crear un nuevo paciente: ' url='/create-patient' urlText="Click aquí"/>
+      </Fragment>
+  );
+}
+ 
+export default PatientsPage;

--- a/src/features/select-treatments/select-treatments.module.scss
+++ b/src/features/select-treatments/select-treatments.module.scss
@@ -6,7 +6,7 @@
 
 .Title {
   color: $brand;
-  font-size: $form-title-size;
+  font-size: $font-size-title;
 }
 
 // I have to set margin as important due to materialUi styles was set as preference

--- a/src/networking/api-routes.ts
+++ b/src/networking/api-routes.ts
@@ -4,6 +4,7 @@
 */
 const API_ROUTES = {
   CREATE_PATIENT: 'patients/',
+  LIST_PATIENTS: 'patients/'
 };
 
 export { API_ROUTES };


### PR DESCRIPTION
Vista para listar pacientes con paginación incluida!
Se agregan algunos colores a la lista de variables de CSS.
Se crea componente Call_to_Action reutilizable para redirecciones dentro del sitio.

Se decide definir la ruta: LIST_PATIENTS que es la misma que CREATE_PATIENT solo para que quede mas legible el código

Material no soporta que la página inicial no sea 0, entonces se le suma una al momento de pedir la data al backend.

### TODO:
Hacer el componente de la tabla reutilizable pasandole como props las columnas de la tabla

### VIDEO:
![listPatients](https://user-images.githubusercontent.com/50835054/146075323-4b9a4056-a6e4-44ed-874a-ce3718b5e027.gif)

