### PR TITLE
Arreglo en flujo de breadcrumbs

### DIFF
--- a/src/context/SimulationGlobalState.tsx
+++ b/src/context/SimulationGlobalState.tsx
@@ -58,4 +58,4 @@ const useSimulationGlobalState = () => {
   return context;
 };
 
-export { SimulationGlobalStateProvider, useSimulationGlobalState };
+export { SimulationGlobalStateProvider, useSimulationGlobalState, SimulationGlobalStateContext };

--- a/src/context/SimulationGlobalState.tsx
+++ b/src/context/SimulationGlobalState.tsx
@@ -58,4 +58,4 @@ const useSimulationGlobalState = () => {
   return context;
 };
 
-export { SimulationGlobalStateProvider, useSimulationGlobalState, SimulationGlobalStateContext };
+export { SimulationGlobalStateProvider, useSimulationGlobalState };

--- a/src/features/select-patient-model/select-patient-model.tsx
+++ b/src/features/select-patient-model/select-patient-model.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useEffect, useContext } from "react";
+import { Fragment, useState, useEffect } from "react";
 import styles from "./select-patient-model.module.scss";
 import { TextField, Tooltip, Button, Grid } from "@material-ui/core";
 import Box from "@mui/material/Box";
@@ -10,25 +10,24 @@ import API from "../../networking/api-service";
 import { API_ROUTES } from "../../networking/api-routes";
 import { Forward } from "@mui/icons-material";
 import ChildModal from "../modal-patient/modal";
-import { useSimulationGlobalState, SimulationGlobalStateContext } from "../../context/SimulationGlobalState";
+import { useSimulationGlobalState } from "../../context/SimulationGlobalState";
 import { Routing } from "../../constant/Routing";
 import Breadcrumbs from "../breadcrumbs/breadcrumbs";
 import { useNavigate } from "react-router-dom";
 
 const SelectPatientModel = () => {
   const navigation = useNavigate();
-  const globalState = useContext(SimulationGlobalStateContext);
+  const { state, setState } = useSimulationGlobalState();
   const [data, setData] = useState({
-    document_number: globalState.state.document_number ? globalState.state.document_number : 0,
-    model_id: globalState.state.model_id ? globalState.state.model_id : 0,
-    model_name: globalState.state.model_name ? globalState.state.model_name : "" as any,
+    document_number: state.document_number ? state.document_number : 0,
+    model_id: state.model_id ? state.model_id : 0,
+    model_name: state.model_name ? state.model_name : "" as any,
   });
 
   const [models, setModels] = useState([] as ModelInfo[]);
 
   const [open, setOpen] = useState(false);
 
-  const { state, setState } = useSimulationGlobalState();
   const breadcrumbs = [
     {
       name: "Inicio",

--- a/src/features/select-patient-model/select-patient-model.tsx
+++ b/src/features/select-patient-model/select-patient-model.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useState, useEffect } from "react";
+import { Fragment, useState, useEffect, useContext } from "react";
 import styles from "./select-patient-model.module.scss";
 import { TextField, Tooltip, Button, Grid } from "@material-ui/core";
 import Box from "@mui/material/Box";
@@ -10,17 +10,18 @@ import API from "../../networking/api-service";
 import { API_ROUTES } from "../../networking/api-routes";
 import { Forward } from "@mui/icons-material";
 import ChildModal from "../modal-patient/modal";
-import { useSimulationGlobalState } from "../../context/SimulationGlobalState";
+import { useSimulationGlobalState, SimulationGlobalStateContext } from "../../context/SimulationGlobalState";
 import { Routing } from "../../constant/Routing";
 import Breadcrumbs from "../breadcrumbs/breadcrumbs";
 import { useNavigate } from "react-router-dom";
 
 const SelectPatientModel = () => {
   const navigation = useNavigate();
+  const globalState = useContext(SimulationGlobalStateContext);
   const [data, setData] = useState({
-    document_number: 0,
-    model_id: 0,
-    model_name: "" as any,
+    document_number: globalState.state.document_number ? globalState.state.document_number : 0,
+    model_id: globalState.state.model_id ? globalState.state.model_id : 0,
+    model_name: globalState.state.model_name ? globalState.state.model_name : "" as any,
   });
 
   const [models, setModels] = useState([] as ModelInfo[]);
@@ -143,6 +144,7 @@ const SelectPatientModel = () => {
                   variant="outlined"
                   placeholder="Ingrese la cedula"
                   type="number"
+                  value={data.document_number}
                   error={!validateFields(data.document_number, data.model_id)}
                   onChange={handleInputChange}
                 />

--- a/src/features/select-treatments/select-treatments.tsx
+++ b/src/features/select-treatments/select-treatments.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState, useContext} from "react";
+import { Fragment, useState} from "react";
 import styles from "./select-treatments.module.scss";
 import {
   TextField,
@@ -14,17 +14,16 @@ import Card from "@mui/material/Card";
 import CardActions from "@mui/material/CardActions";
 import CardContent from "@mui/material/CardContent";
 import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
-import { setTreatments } from "./treatmentSlice";
 import { useAppDispatch } from "../../app/store/hooks";
 import Breadcrumbs from "../breadcrumbs/breadcrumbs";
 import { Routing } from "../../constant/Routing";
 import { useNavigate } from "react-router-dom";
-import { useSimulationGlobalState, SimulationGlobalStateContext } from "../../context/SimulationGlobalState";
+import { useSimulationGlobalState } from "../../context/SimulationGlobalState";
 
 const SelectTreatments = () => {
   const navigation = useNavigate();
   const dispatch = useAppDispatch();
-  const globalState = useContext(SimulationGlobalStateContext);
+  const { state, setState } = useSimulationGlobalState();
 
   const [datos, setData] = useState({
     cycle_duration: 0,
@@ -33,14 +32,13 @@ const SelectTreatments = () => {
   });
 
   const setCardsFromContext = () => {
-    if (globalState.state.treatments)
-      return globalState.state.treatments
+    if (state.treatments)
+      return state.treatments
     else
       return [] as TreatmentJSON[]
   }
 
   const [cards, setCards] = useState<TreatmentJSON[]>(setCardsFromContext());
-  const { state, setState } = useSimulationGlobalState();
 
   const breadcrumbs = [
     {

--- a/src/features/select-treatments/select-treatments.tsx
+++ b/src/features/select-treatments/select-treatments.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment, useState, useContext} from "react";
 import styles from "./select-treatments.module.scss";
 import {
   TextField,
@@ -19,11 +19,12 @@ import { useAppDispatch } from "../../app/store/hooks";
 import Breadcrumbs from "../breadcrumbs/breadcrumbs";
 import { Routing } from "../../constant/Routing";
 import { useNavigate } from "react-router-dom";
-import { useSimulationGlobalState } from "../../context/SimulationGlobalState";
+import { useSimulationGlobalState, SimulationGlobalStateContext } from "../../context/SimulationGlobalState";
 
 const SelectTreatments = () => {
   const navigation = useNavigate();
   const dispatch = useAppDispatch();
+  const globalState = useContext(SimulationGlobalStateContext);
 
   const [datos, setData] = useState({
     cycle_duration: 0,
@@ -31,7 +32,14 @@ const SelectTreatments = () => {
     quantity: 0,
   });
 
-  const [cards, setCards] = useState<TreatmentJSON[]>([]);
+  const setCardsFromContext = () => {
+    if (globalState.state.treatments)
+      return globalState.state.treatments
+    else
+      return [] as TreatmentJSON[]
+  }
+
+  const [cards, setCards] = useState<TreatmentJSON[]>(setCardsFromContext());
   const { state, setState } = useSimulationGlobalState();
 
   const breadcrumbs = [


### PR DESCRIPTION
Ahora se puede ir para atras y no perder la data previamente seteada.
Una vez que se retoma el flujo la data de pasos siguientes tmb se persiste

Aca se explica un poco mas un comportamiento que no se soporta
https://grupotesis-fing.slack.com/archives/C021MG55PV1/p1645288244306459

![breadcrumbsContext](https://user-images.githubusercontent.com/50835054/154809857-aab5c948-bbd5-4d73-a386-67533d4716aa.gif)
