### PR TITLE
Fix treatments card bug

### DIFF
--- a/src/features/metrics-card/metrics-card.tsx
+++ b/src/features/metrics-card/metrics-card.tsx
@@ -91,7 +91,7 @@ const MetricsCard = (props: any) => {
         "\n"
       );
     });
-    pdf.text("Metricas \n", 10, 10, {
+    pdf.text("Métricas \n", 10, 10, {
       maxWidth: 100,
     });
     pdf.text(metrics, 10, 20, {

--- a/src/features/simulation-page/simulation-page.tsx
+++ b/src/features/simulation-page/simulation-page.tsx
@@ -108,7 +108,7 @@ const SimulationPage = () => {
           <Typography className={styles.Treatmentsubtitle}>
             Tratamientos:
           </Typography>
-          <Grid container spacing={2}>
+          <Grid container spacing={2} justifyContent="center">
             {cards.map((treatment: TreatmentJSON, index: number) => (
               <TreatmentCard
                 treatment={treatment}


### PR DESCRIPTION
Agrega tilde a "Métricas" en reporte
Cuando habían 3 tratameintos quedaban descentrados
Antes:
![Screenshot from 2022-06-14 22-19-46](https://user-images.githubusercontent.com/50835054/173716129-aa7dcd1d-6503-454a-9a35-e846772c5eac.png)

Ahora:
![Screenshot from 2022-06-14 22-19-26](https://user-images.githubusercontent.com/50835054/173716141-2ff9a7dd-edc2-4c91-a83f-e41053f90ba8.png)

